### PR TITLE
Add scroll behaviour to vue router

### DIFF
--- a/website/client/src/main.js
+++ b/website/client/src/main.js
@@ -182,7 +182,13 @@ const routes = [
 const router = new VueRouter({
   routes,
   mode: 'history',
-  hashbang: false
+  hashbang: false,
+  scrollBehavior: function (to, from, savedPosition) {
+    if (to.name === 'PlayGame') {
+      return { y: 0 }
+    }
+    return savedPosition
+  }
 })
 
 router.beforeEach((to, from, next) => {


### PR DESCRIPTION
Update scroll behaviour on vue router so that navigating to game play pages always scrolls to the top, but other pages preserve positioning. 